### PR TITLE
Add CatCommand for category-based filtering

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CatCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CatCommand.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+
+/**
+ * Finds and lists all persons in address book whose category matches the specified category.
+ * Category matching is case insensitive.
+ */
+public class CatCommand extends Command {
+
+    public static final String COMMAND_WORD = "cat";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose category matches "
+            + "the specified category (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: CATEGORY\n"
+            + "Example: " + COMMAND_WORD + " florist";
+
+    public static final String MESSAGE_SUCCESS = "Category filter applied: %1$s";
+
+    private final String category;
+
+    public CatCommand(String category) {
+        this.category = category;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        // Placeholder implementation - actual filtering will be implemented when Category field is added
+        return new CommandResult(String.format(MESSAGE_SUCCESS, category));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CatCommand)) {
+            return false;
+        }
+
+        CatCommand otherCatCommand = (CatCommand) other;
+        return category.equals(otherCatCommand.category);
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CatCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case CatCommand.COMMAND_WORD:
+            return new CatCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/CatCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CatCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.CatCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new CatCommand object
+ */
+public class CatCommandParser implements Parser<CatCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CatCommand
+     * and returns a CatCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CatCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CatCommand.MESSAGE_USAGE));
+        }
+
+        return new CatCommand(trimmedArgs);
+    }
+
+}
+


### PR DESCRIPTION
This pull request introduces a new command to filter persons in the address book by category. The changes add the `cat` command, its parser, and integrate it into the command parsing logic. The current implementation is a placeholder and will fully function once the category field is added to the model.

### New Command Addition

* Added `CatCommand` class to allow filtering persons by a specified category, with case-insensitive matching. The command currently returns a success message and awaits full filtering logic when the category field is available. (`src/main/java/seedu/address/logic/commands/CatCommand.java`)

### Command Parsing Integration

* Registered `CatCommand` in the main parser so that it can be recognized and executed from user input. (`src/main/java/seedu/address/logic/parser/AddressBookParser.java`) [[1]](diffhunk://#diff-399c284cb892c20b7c04a69116fcff6ccc0666c5230a1db8e4a9145def8fa4eeR12) [[2]](diffhunk://#diff-399c284cb892c20b7c04a69116fcff6ccc0666c5230a1db8e4a9145def8fa4eeR72-R74)
* Implemented `CatCommandParser` to handle parsing and validation of user input for the `cat` command, ensuring proper format and error handling. (`src/main/java/seedu/address/logic/parser/CatCommandParser.java`)