### PR TITLE
Make height of result display + details panel bigger

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,8 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="KnotBook" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.scene.control.ScrollPane?>
+<fx:root minHeight="700" minWidth="700" onCloseRequest="#handleExit" title="KnotBook" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>
@@ -64,12 +65,12 @@
 
                                 <StackPane fx:id="personDetailsPlaceholder"
                                            VBox.vgrow="ALWAYS"
-                                           minHeight="0.0"
+                                           minHeight="300.0"
                                            maxWidth="Infinity" />
 
                                 <StackPane fx:id="resultDisplayPlaceholder"
                                            VBox.vgrow="NEVER"
-                                           minHeight="100.0"
+                                           minHeight="150.0"
                                            maxHeight="200.0"
                                            maxWidth="Infinity">
                                     <padding>


### PR DESCRIPTION
## Description

Increase the minimum height of the person details panel and the result display so the UI isn’t cramped/ text is cut off at smaller window sizes.

## Related Issue

<!-- Link to the related issue if applicable (e.g., Fixes #123, Closes #456) -->

Closes #78 

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

<!-- List the main changes made in this PR -->

- Raised minHeight of the person details container + result display container in FXML.
-
-

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

-
-

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, context, or screenshots about the PR -->
