### PR TITLE
Strengthen email validation to require TLD

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -28,7 +28,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -51,15 +51,18 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("a@bc")); // missing top level domain
+        assertFalse(Email.isValidEmail("test@localhost")); // missing top level domain
+        assertFalse(Email.isValidEmail("123@123")); // missing top level domain
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("a@bc.com")); // minimal with proper domain
+        assertTrue(Email.isValidEmail("test@localhost.local")); // localhost with proper domain
+        assertTrue(Email.isValidEmail("123@123.com")); // numeric local part and domain name with proper TLD
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +71,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +86,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }


### PR DESCRIPTION
## Description

Fixed email validation to properly reject emails without proper domain structure (e.g., `123@123`) while accepting valid emails with proper TLD (e.g., `123@123.com`).

## Related Issue

fixes #116 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/modification

## Changes Made

- Updated `DOMAIN_REGEX` in `Email.java` to require at least one dot in domain structure (changed `*` to `+`)
- Added test cases to reject emails without proper TLD structure
- Updated existing test cases to use proper domain format
- Fixed `equals()` test method to use valid email format

## Testing Done

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

- `123@123` → **REJECTED** (no TLD)
- `123@123.com` → **ACCEPTED** (proper domain structure)
- `test@example.c` → **REJECTED** (TLD too short)
- `test@example.com` → **ACCEPTED** (valid format)
- `a@bc` → **REJECTED** (missing TLD)
- `a@bc.com` → **ACCEPTED** (minimal valid format)

## Screenshots (if applicable)

N/A - Backend validation changes

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The fix ensures email validation follows standard email format requirements:
- Requires at least one dot in the domain
- TLD must be at least 2 characters
- Maintains existing validation for special characters and other constraints

**Files modified:**
- `src/main/java/seedu/address/model/person/Email.java`
- `src/test/java/seedu/address/model/person/EmailTest.java`

**Validation behavior:**
- Before: `123@123` was incorrectly accepted
- After: `123@123` is correctly rejected, `123@123.com` is accepted