### PR TITLE
Make type labels non-collapsible

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,7 +27,11 @@
           </minWidth>
         </Label>
         <Label fx:id="name" text="$first" styleClass="cell_big_label" />
-        <Label fx:id="typeChip" text="client" styleClass="type-chip"/>
+        <Label fx:id="typeChip" text="client" styleClass="type-chip">
+          <minWidth>
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
       </HBox>
 
       <FlowPane fx:id="tags" />


### PR DESCRIPTION
## Description

Make the labels on the person list cards (client, vendor) uncollapsible.

## Related Issue

Closes #156

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

## Screenshots (if applicable)

<img width="309" height="488" alt="image" src="https://github.com/user-attachments/assets/11247c79-2487-4370-828d-0a528b92f4c1" />

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

