### PR TITLE
Make contact list have a minimum width

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -48,6 +48,7 @@
                             <VBox fx:id="personList"
                                   fillWidth="true"
                                   spacing="16.0"
+                                  minWidth="200.0"
                                   maxWidth="Infinity">
                                 <padding>
                                     <Insets top="10" right="10" bottom="10" left="10"/>


### PR DESCRIPTION
## Description

Prevents the contact list from being able to be collapsed to 0px.

## Related Issue

Closes #130 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

Add a minWidth to personList in the MainWindow.fxml

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Manual testing performed

**Test cases:**

-
-

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, context, or screenshots about the PR -->
