### PR TITLE
Clarify single-line command input requirement in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -91,6 +91,10 @@ The app window should appear in a few seconds with some sample wedding contacts 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
+* Commands must be entered on a single line. Newlines are not supported.<br>
+  If you copy a command that appears on multiple lines, join it into one line before pressing Enter.
+  Pasting multi-line commands into the command box will fail; replace line breaks with spaces.
+
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 


### PR DESCRIPTION
### Description
Document that commands must be entered on a single line; newlines are not supported. Adds explicit warning that pasting multi-line commands will fail.

### Related Issue
Closes #171

### Type of Change
- [x] Documentation update

### Changes Made
- Added a note under “Notes about the command format” in `docs/UserGuide.md` stating commands must be on a single line and newlines are not supported.
- Added a clarifying line warning that pasting multi-line commands will fail and to replace line breaks with spaces.

### Testing Done
- [x] Manual testing performed

**Test cases:**
- Verified the new note appears correctly in the “Notes about the command format” section of `docs/UserGuide.md`.
- Confirmed guidance is clear by attempting a multi-line paste and observing the existing error message, validating the documentation reflects current behavior.

### Screenshots (if applicable)
N/A

### Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Additional Notes
This PR documents current behavior; no functional changes were made.