### PR TITLE
Remove the ability to link the same pair twice

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -79,7 +79,7 @@ public class LinkCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_VENDOR_INDEX);
         }
 
-        // Check if already linked
+        // Check if already linked (by identity/phone)
         if (client.isLinkedTo(vendor)) {
             throw new CommandException(MESSAGE_LINK_ALREADY_EXISTS);
         }
@@ -100,6 +100,8 @@ public class LinkCommand extends Command {
      */
     private Person createPersonWithLink(Person person, Person linkedPerson) {
         Set<Person> updatedLinks = new HashSet<>(person.getLinkedPersons());
+        // Ensure no duplicate by identity before adding
+        updatedLinks.removeIf(p -> p.isSamePerson(linkedPerson));
         updatedLinks.add(linkedPerson);
 
         if (person.getType() == PersonType.VENDOR) {

--- a/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
@@ -100,7 +100,8 @@ public class UnlinkCommand extends Command {
      */
     private Person createPersonWithoutLink(Person person, Person linkedPerson) {
         Set<Person> updatedLinks = new HashSet<>(person.getLinkedPersons());
-        updatedLinks.remove(linkedPerson);
+        // Remove by identity/phone to avoid equals/hashCode mismatches
+        updatedLinks.removeIf(p -> p.isSamePerson(linkedPerson));
 
         if (person.getType() == PersonType.VENDOR) {
             return new Person(


### PR DESCRIPTION
## Description
Prevent duplicate client–vendor links and make unlink robust to edited instances. Linking now de-duplicates by person identity (phone) before adding, and unlink removes by identity as well. This avoids scenarios where the same pair can be linked twice due to object reference changes after edits.

## Related Issue
Fixes #195 
Fixes #190 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made
- Link: de-duplicate link set by identity before adding the counterpart.
- Unlink: remove counterpart by identity to handle edited instances.
- No changes to user-facing command syntax or messages.

Files changed:
- `src/main/java/seedu/address/logic/commands/LinkCommand.java`
- `src/main/java/seedu/address/logic/commands/UnlinkCommand.java`

## Testing Done
- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

Test cases:
- Duplicate link prevention:
  - Add client A and vendor B, link once → success.
  - Link A–B again → “already linked.”
  - Link A–B a third time → still “already linked.”
- Robust unlink:
  - Link A–B, edit either A or B (e.g., email), unlink → succeeds.
  - After unlink, link again → succeeds exactly once, duplicate attempts blocked.
- Multiple links:
  - Client A linked to vendors B and C; linking A–B again blocked; unlink A–B leaves A–C intact.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published