### PR TITLE
Fix message for price/ budget range + Make equal value ranges invalid

### DIFF
--- a/src/main/java/seedu/address/model/person/Budget.java
+++ b/src/main/java/seedu/address/model/person/Budget.java
@@ -9,8 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Budget {
 
-    public static final String MESSAGE_CONSTRAINTS = "Invalid amount. Provide a number or a range like 800-1500. "
-            + "Only digits and hyphens are allowed (no commas or dollar signs).";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Invalid amount. Enter a number (e.g., 1200) or a range (e.g., 800-1500).\n"
+                    + "Only digits and a single hyphen are allowed (no spaces, commas, or $).\n"
+                    + "For ranges, the left value must be strictly less than the right value.";
 
     /*
      * Accepts:
@@ -49,7 +51,7 @@ public class Budget {
                 try {
                     long min = Long.parseLong(parts[0]);
                     long max = Long.parseLong(parts[1]);
-                    return min <= max;
+                    return min < max;
                 } catch (NumberFormatException e) {
                     return false;
                 }

--- a/src/main/java/seedu/address/model/person/Price.java
+++ b/src/main/java/seedu/address/model/person/Price.java
@@ -9,8 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Price {
 
-    public static final String MESSAGE_CONSTRAINTS = "Invalid amount. Provide a number or a range like 800-1500. "
-            + "Only digits and hyphens are allowed (no commas or dollar signs).";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Invalid amount. Enter a number (e.g., 1200) or a range (e.g., 800-1500).\n"
+                    + "Only digits and a single hyphen are allowed (no spaces, commas, or $).\n"
+                    + "For ranges, the left value must be strictly less than the right value.";
 
     /*
      * Accepts:
@@ -49,7 +51,7 @@ public class Price {
                 try {
                     long min = Long.parseLong(parts[0]);
                     long max = Long.parseLong(parts[1]);
-                    return min <= max;
+                    return min < max;
                 } catch (NumberFormatException e) {
                     return false;
                 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -35,7 +35,7 @@ public class SampleDataUtil {
                         new Budget("8000-15000"), Optional.of(new Partner("Jackson Wang"))),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                         new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                        WeddingDate.parse("10-12-2021"), PersonType.VENDOR, getTagSet("Photography & Videography"),
+                        null, PersonType.VENDOR, getTagSet("Photography & Videography"),
                         new Price("500-1000"), null, Optional.empty()),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                         new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
@@ -47,7 +47,7 @@ public class SampleDataUtil {
                         new Budget("10000-15000"), Optional.of(new Partner("Siti Nur"))),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                         new Address("Blk 45 Aljunied Street 85, #11-31"),
-                        WeddingDate.parse("25-09-2020"), PersonType.VENDOR, getTagSet("Wedding Planning & Events"),
+                        null, PersonType.VENDOR, getTagSet("Wedding Planning & Events"),
                         new Price("2000-3500"), null, Optional.empty())
         };
     }

--- a/src/test/java/seedu/address/model/person/BudgetTest.java
+++ b/src/test/java/seedu/address/model/person/BudgetTest.java
@@ -36,6 +36,7 @@ public class BudgetTest {
         assertFalse(Budget.isValidBudget("100-200-300")); // multiple ranges
         assertFalse(Budget.isValidBudget("12345678901")); // too many digits (>10)
         assertFalse(Budget.isValidBudget("5000-1000")); // invalid range (min > max)
+        assertFalse(Budget.isValidBudget("1000-1000")); // equal min and max
 
         // invalid budgets - with special characters
         assertFalse(Budget.isValidBudget("$1000")); // dollar sign not allowed
@@ -57,7 +58,6 @@ public class BudgetTest {
         assertTrue(Budget.isValidBudget("800-1500")); // simple range
         assertTrue(Budget.isValidBudget("100-200")); // small range
         assertTrue(Budget.isValidBudget("1000-5000")); // medium range
-        assertTrue(Budget.isValidBudget("1000-1000")); // equal min and max (valid)
     }
 
     @Test


### PR DESCRIPTION
## Description

Disallow equal-endpoint ranges for Price and Budget (e.g., 900-900) and clarify error messages. Updates validators, messages, and tests accordingly.

## Related Issue

Closes #137
Closes #204
Closes #206

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/modification

## Changes Made

<!-- List the main changes made in this PR -->

- Updated Budget.MESSAGE_CONSTRAINTS and Price.MESSAGE_CONSTRAINTS to state: “left value must be strictly less than the right value.”
- Tightened validators: in isValidBudget and isValidPrice, change min <= max → min < max.

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

- Mark 1000-1000 as invalid

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, context, or screenshots about the PR -->
