### PR TITLE
Replace Client with Wedding Date in Linked Section + Add Phone Number for Uniqueness

### DIFF
--- a/src/main/java/seedu/address/ui/PersonDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/PersonDetailsPanel.java
@@ -166,7 +166,7 @@ public class PersonDetailsPanel extends UiPart<Region> {
                         // Prefix = wedding date when the selected person is a VENDOR and the linked is a CLIENT
                         String prefix;
                         if (person.getType() == PersonType.VENDOR && p.getType() == PersonType.CLIENT) {
-                            prefix = fmtDate(p);                    // e.g., "2025-10-12"
+                            prefix = fmtDate(p);
                         } else {
                             // fallback to your existing category/type label
                             prefix = p.getTags().stream()


### PR DESCRIPTION
## Description

Show wedding date instead of the literal “Client” label in a vendor’s linked section, and append phone numbers to linked names for uniqueness.

## Related Issue

Closes #148 
Closes #187

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

<!-- List the main changes made in this PR -->

- Updated Linked entries
- Display: vendor view uses client’s wedding date as prefix; names via DisplayFormat.nameAndPartner(p) for clients, plain name for vendors; always append phone.

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

-
-

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, context, or screenshots about the PR -->
