### PR TITLE
Make Input Command Box UI better

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -32,6 +33,19 @@ public class CommandBox extends UiPart<Region> {
 
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        commandTextField.addEventHandler(ScrollEvent.SCROLL, e -> e.consume());
+
+        getRoot().addEventFilter(ScrollEvent.SCROLL, e -> {
+            if (commandTextField.isHover()) {
+                e.consume();
+            }
+        });
+
+        commandTextField.setOnScroll(e -> {
+            commandTextField.setScrollTop(commandTextField.getScrollTop() - e.getDeltaY());
+            e.consume();
+        });
 
         // Handle Enter key to execute command (Shift+Enter for new line)
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -5,6 +5,7 @@
 
 <StackPane fx:id="commandBoxRoot" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="commandTextField"
+            styleClass="command-input"
             promptText="Enter command here..."
             wrapText="true"
             prefRowCount="2"

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -335,3 +335,54 @@
 .scroll-pane > .viewport {
     -fx-background-color: transparent;
 }
+
+.text-area.command-input {
+  -fx-font-size: 13pt;
+  -fx-padding: 0;
+}
+.text-area.command-input .content {
+  -fx-padding: 6 10 6 6;
+}
+
+.text-area.command-input .scroll-pane .scroll-bar:vertical   { -fx-pref-width: 10; }
+.text-area.command-input .scroll-pane .scroll-bar:horizontal { -fx-pref-height: 10; }
+.text-area.command-input .scroll-pane .scroll-bar { -fx-opacity: 1.0; }
+
+.text-area.command-input .scroll-pane .scroll-bar .track {
+  -fx-background-color: #F9E6E8 !important;
+  -fx-background-insets: 0;
+  -fx-background-radius: 999;
+  -fx-border-color: -app-border;
+  -fx-border-width: 1;
+  -fx-border-radius: 999;
+}
+.text-area.command-input .scroll-pane .scroll-bar .thumb {
+  -fx-background-color: #D8A8A8 !important;
+  -fx-background-insets: 1;
+  -fx-background-radius: 999;
+  -fx-border-color: transparent;
+  -fx-border-radius: 999;
+  -fx-opacity: 1;
+  -fx-min-height: 14px;
+  -fx-min-width: 14px;
+}
+.text-area.command-input .scroll-pane .scroll-bar .thumb:hover   { -fx-background-color: #C98C8C !important; }
+.text-area.command-input .scroll-pane .scroll-bar .thumb:pressed { -fx-background-color: derive(#C98C8C, -12%) !important; }
+
+.text-area.command-input .scroll-pane .corner { -fx-background-color: white !important; }
+
+.text-area.command-input .scroll-pane .increment-button,
+.text-area.command-input .scroll-pane .decrement-button,
+.text-area.command-input .scroll-pane .increment-arrow,
+.text-area.command-input .scroll-pane .decrement-arrow {
+  -fx-padding: 0;
+  -fx-background-color: transparent;
+  -fx-shape: null;
+  -fx-opacity: 0;
+  -fx-max-width: 0;
+  -fx-max-height: 0;
+  -fx-pref-width: 0;
+  -fx-pref-height: 0;
+  -fx-min-width: 0;
+  -fx-min-height: 0;
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -83,7 +83,7 @@
                                            prefHeight="60.0"
                                            maxWidth="Infinity">
                                     <padding>
-                                        <Insets top="2.0" right="10.0" left="10.0"/>
+                                        <Insets top="2.0" right="10.0" left="0.0"/>
                                     </padding>
                                 </StackPane>
 


### PR DESCRIPTION
## Description

Improve the Input Command Box (TextArea) UX to match app scrollbars and feel better for typing

## Related Issue

Closes #189

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

<!-- List the main changes made in this PR -->

- Use the same draggable scrollbar theme as the rest of the app.
- Wheel/trackpad scrolling works inside the box (no more clicky arrow-only).
- Reduce left padding; larger font for readability.

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

-
-

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, context, or screenshots about the PR -->
