### PR TITLE
corrected error msg

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -36,14 +36,14 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_WEDDING_DATE + "DATE "
             + PREFIX_TYPE + "(client|vendor) "
+            + "[" + PREFIX_WEDDING_DATE + "DATE] "
             + "[" + PREFIX_PRICE + "PRICE] "
             + "[" + PREFIX_BUDGET + "BUDGET] "
             + "[" + PREFIX_PARTNER + "PARTNER] "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "  For clients only: " + PREFIX_PARTNER + "PARTNER, [" + PREFIX_BUDGET
-            + "BUDGET] (e.g., 5000 or 5000-10000)\n"
+            + "  For clients only: " + PREFIX_WEDDING_DATE + "DATE, " + PREFIX_PARTNER + "PARTNER, ["
+            + PREFIX_BUDGET + "BUDGET] (e.g., 5000 or 5000-10000)\n"
             + "  For vendors only: [" + PREFIX_PRICE + "PRICE] (e.g., 1000 or 1000-2000), [" + PREFIX_TAG
             + "TAG]...\n\n"
             + "Example 1 (Client): " + COMMAND_WORD + " "


### PR DESCRIPTION
## Description

Fixed the `add` command help message and UserGuide to correctly reflect that wedding date is only compulsory for clients, not vendors. Updated the command format to split client and vendor examples clearly, and modified the parameters documentation to show `w/DATE` as required for clients but optional for vendors.

## Related Issue

Fixes #214 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

<!-- List the main changes made in this PR -->

- Updated `AddCommand.java` MESSAGE_USAGE to show wedding date as optional in general parameters section
- Modified MESSAGE_USAGE to explicitly list wedding date as required for clients only (alongside partner)
- Split UserGuide `add` command format into separate formats for clients and vendors
- Updated UserGuide parameters section to clarify wedding date is "required for clients, optional for vendors"
- Updated all examples in UserGuide to reflect correct usage for clients and vendors
- Updated FAQ section to explain wedding date requirements
- Updated Command Summary table with correct formats for both client and vendor types

## Testing Done

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**

- Verified help message displays correctly with `help` command
- Tested adding client without wedding date - correctly fails with validation error
- Tested adding vendor without wedding date - correctly succeeds
- Tested adding client with wedding date - correctly succeeds
- Verified UserGuide renders correctly in Jekyll with updated formats

## Screenshots (if applicable)

**Before (Issue #214):**
The help message showed wedding date as required for both clients and vendors, causing confusion.

**After:**
Help message now clearly shows:
- General parameters list `w/DATE` as optional `[w/DATE]`
- "For clients only" section explicitly requires `w/DATE` (without brackets)
- "For vendors only" section does not mention wedding date

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This fix addresses a critical UX issue where the help message and documentation were misleading users about wedding date requirements. The changes make it crystal clear that:

1. **For clients**: Wedding date is **mandatory** (like partner name)
2. **For vendors**: Wedding date is **optional** (and typically not needed)

This aligns with the actual validation logic in the codebase and prevents users from being confused about what fields are required for each person type. The split format in both the help message and UserGuide makes the distinction immediately obvious.

**Design rationale**: Wedding dates are inherently tied to clients (the couples getting married), not to vendors (service providers). While vendors might need to know the wedding date, it's not a defining attribute of the vendor contact itself - the association is managed through the `link` command instead.