### PR TITLE
Remove auto-capitalisation in client details panel when a link is pre…

### DIFF
--- a/src/main/java/seedu/address/ui/PersonDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/PersonDetailsPanel.java
@@ -168,11 +168,11 @@ public class PersonDetailsPanel extends UiPart<Region> {
                         if (person.getType() == PersonType.VENDOR && p.getType() == PersonType.CLIENT) {
                             prefix = fmtDate(p);
                         } else {
-                            // fallback to your existing category/type label
+                            // Use the first category if present, preserving original casing; otherwise use type
                             prefix = p.getCategories().stream()
                                     .sorted(Comparator.comparing(c -> c.categoryName))
                                     .findFirst()
-                                    .map(c -> capitalize(c.categoryName))
+                                    .map(c -> c.categoryName)
                                     .orElse(p.getType().display());
                         }
 
@@ -197,15 +197,5 @@ public class PersonDetailsPanel extends UiPart<Region> {
             linkedPersonsLine.setVisible(true);
             linkedPersonsLine.setManaged(true);
         }
-    }
-
-    /**
-     * Capitalizes the first letter of a string.
-     */
-    private String capitalize(String str) {
-        if (str == null || str.isEmpty()) {
-            return str;
-        }
-        return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 }


### PR DESCRIPTION
## Description
Preserve original casing for vendor categories shown in the linked persons section. Previously, the first category was auto-capitalized (e.g., “delivery” → “Delivery”). Now it displays exactly as stored (“delivery”), ensuring consistency with the category chips/tags.

## Related Issue
Fixes #172 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Use the first linked person category as-is (no capitalization) when building the vendors/clients list prefix in `PersonDetailsPanel`.
- Remove the now-unused capitalization helper method.
- Keep categories line label logic unchanged; only prefix casing behavior modified.

## Testing Done
- [x] All existing tests pass
- [x] Manual testing performed

Test cases:
- Select a client linked to a vendor whose first category is lowercase (e.g., “delivery”); verify the vendors section shows “delivery” (not “Delivery”).
- Verify vendors with no categories still fall back to type display.
- Verify other fields (price, budget, wedding date visibility) remain unaffected.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (none needed beyond changed section)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (manual verification only)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (N/A)

## Additional Notes
This change aligns the vendors section with the categories/tags component, eliminating confusing casing discrepancies for users.