### PR TITLE
Remove deleted person from others' linked persons

### DIFF
--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -39,6 +39,7 @@ public class PersonBuilder {
     private Price price;
     private Budget budget;
     private Optional<Partner> partner;
+    private Set<Person> linkedPersons;
 
 
     /**
@@ -55,6 +56,7 @@ public class PersonBuilder {
         price = null;
         budget = null;
         partner = Optional.of(new Partner(DEFAULT_PARTNER));
+        linkedPersons = new HashSet<>();
     }
 
     /**
@@ -71,6 +73,7 @@ public class PersonBuilder {
         price = personToCopy.getPrice().orElse(null);
         budget = personToCopy.getBudget().orElse(null);
         partner = personToCopy.getPartner();
+        linkedPersons = new HashSet<>(personToCopy.getLinkedPersons());
     }
 
     /**
@@ -197,6 +200,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code linkedPersons} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withLinkedPersons(Set<Person> linkedPersons) {
+        this.linkedPersons = linkedPersons;
+        return this;
+    }
+
+    /**
      * Builds a Person object using the appropriate constructor based on the person type.
      * @return a Person object
      */
@@ -205,10 +216,17 @@ public class PersonBuilder {
             if (partner != null && partner.isPresent()) {
                 throw new IllegalArgumentException("Vendors cannot have a partner");
             }
+            if (linkedPersons != null && !linkedPersons.isEmpty()) {
+                return new Person(name, phone, email, address, type, categories, linkedPersons, price);
+            }
             return new Person(name, phone, email, address, type, categories, price);
         } else {
             if (partner == null || partner.isEmpty()) {
                 throw new IllegalArgumentException("Clients must have a partner");
+            }
+            if (linkedPersons != null && !linkedPersons.isEmpty()) {
+                return new Person(name, phone, email, address, weddingDate, type, categories,
+                        linkedPersons, price, budget, partner);
             }
             return new Person(name, phone, email, address, weddingDate, type, categories, price, budget, partner);
         }


### PR DESCRIPTION
## Description

Fixes an issue where, after deleting a contact, the details panel could still show stale, linked contact information. The deletion now:
- Removes the person from the address book, and
- Automatically unlinks the deleted person from all other contacts’ linked persons,
ensuring the details panel reflects the correct state (clears if the selected person was deleted; updates otherwise).

## Related Issue

Fixes #236

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test addition/modification

## Changes Made

- Updated `AddressBook.removePerson(...)` to:
  - Remove the target from all other persons’ `linkedPersons` via `removeLinkedPersonReferences(...)`.
  - Then remove the person from the internal list.
- Added `removeLinkedPersonReferences(...)` helper to rebuild affected persons with updated link sets while preserving all other fields.
- Added `withLinkedPersons(...)` support to `PersonBuilder` (test utility).
- Added a test verifying that deleting a person removes them from others’ `linkedPersons`.

Key files:
- `src/main/java/seedu/address/model/AddressBook.java`
- `src/test/java/seedu/address/testutil/PersonBuilder.java`
- `src/test/java/seedu/address/logic/commands/DeleteCommandTest.java`

## Testing Done

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manual testing performed

**Test cases:**
- New: `execute_deletePersonWithLinkedPersons_removesFromLinkedPersons`
  - Creates a client and vendor, links them, deletes the vendor, and asserts the client no longer has the vendor in `linkedPersons`.
- Manual:
  - Select a contact in the list, link them to another, delete one of them, and verify:
    - The details panel clears if the selected contact was deleted.
    - Linked persons list no longer shows the deleted contact.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in non-obvious areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This leverages the existing `MainWindow` behavior to refresh the details panel after each command. By ensuring the model unlinks deleted persons first, the UI now reflects the correct state automatically.