### PR TITLE
DG fix

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -607,7 +607,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * 1a. User enters an empty category.
 
-    * 1a1. KnotBook shows an error message: "Category cannot be empty."
+    * 1a1. KnotBook shows an error message: "Invalid command format!"
 
       Use case ends.
 
@@ -825,7 +825,7 @@ testers are expected to do more *exploratory* testing.
       Expected: Only contacts categorized as "photographer" are displayed (case-insensitive matching).
 
    1. Test case: `cat`<br>
-      Expected: Error message indicating that category cannot be empty.
+      Expected: Error message "Invalid command format!" with command usage details.
 
    1. Test case: `cat nonexistent`<br>
       Expected: Empty list displayed with message indicating no contacts found for that category.


### PR DESCRIPTION
# Developer Guide Fixes

This PR tracks all fixes made to the Developer Guide (DG) to align it with the actual implementation.


---
Closes #323 
Closes #322 
Closes #315  
Closes #310 
Closes #306 
Closes #305 
Closes #303 
Closes #299 
Closes #293 
Closes #275 
Closes #267 
Closes #266 
Closes #265 
Closes #264 

Duplicate Contact Detection - Phone Only

**Date**: 3 November 2025  
**Issue**: DG stated that KnotBook checks for duplicates by "phone OR email", but the actual implementation only checks by phone number.  
**Reference**: GitHub Issue - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location 1 - Main Flow (Line 632)**
- **Before**: "KnotBook checks for duplicate contacts (same phone or email)"
- **After**: "KnotBook checks for duplicate contacts (same phone number)"

**Location 2 - Extension Case 8a (Line 694)**
- **Before**: "8a. Duplicate contact detected (same phone or email)."
- **After**: "8a. Duplicate contact detected (same phone number)."

### Rationale

The actual implementation in `AddressBook.java` and `Person.java` only uses phone number to identify duplicates. Two people with the same email can be added successfully, but two people with the same phone number cannot. The DG needed to reflect this accurate behavior.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None (implementation was already correct)

---

Wedding Date Prefix Notation

**Date**: 3 November 2025  
**Issue**: DG documentation shows `date:` prefix but actual implementation uses `w/` (per User Guide and application).  
**Reference**: GitHub Issue - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location 1 - Key Components Section (Line 247)**
- **Before**: "`AddCommandParser` - Parses the `date:` prefix to extract wedding dates"
- **After**: "`AddCommandParser` - Parses the `w/` prefix to extract wedding dates"

**Location 2 - Extension Case 6a Error Message (Line 666)**
- **Before**: "KnotBook shows error: \"Wedding date is required for clients. Example: date:2025-10-12\""
- **After**: "KnotBook shows error: \"Wedding date is required for clients. Example: w/2025-10-12\""

**Location 3 - Test Case Example (Line 884)**
- **Before**: "`add n/John Doe p/98765432 e/john@example.com a/123 Street date:12-10-2025 type/client t/friends`"
- **After**: "`add n/John Doe p/98765432 e/john@example.com a/123 Street w/12-10-2025 type/client t/friends`"

### Status

✅ **FIXED** - All 3 occurrences of `date:` prefix updated to `w/` to match actual implementation and User Guide.

### Rationale

The User Guide clearly shows `w/` as the prefix for wedding dates in commands like:
```
add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 w/15-06-2025 type/client pr/Jane Doe
```

The DG must maintain consistency with the User Guide and actual implementation.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None (implementation is correct, only DG examples needed updating)
- grep_search confirmed: No remaining `date:` prefix notation in DG examples

---

Category Prefix Notation

**Date**: 3 November 2025  
**Issue**: DG test case examples show `t/` prefix for categories, but actual implementation uses `c/` (per User Guide and application).  
**Reference**: GitHub Issue - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location 1 - Client Test Case (Line 884)**
- **Before**: "`add n/John Doe p/98765432 e/john@example.com a/123 Street w/12-10-2025 type/client t/friends`"
- **After**: "`add n/John Doe p/98765432 e/john@example.com a/123 Street w/12-10-2025 type/client c/friends`"

**Location 2 - Vendor Test Case (Line 892)**
- **Before**: "`add n/Flower Shop p/91234567 e/flowers@example.com a/789 Road type/vendor t/florist`"
- **After**: "`add n/Flower Shop p/91234567 e/flowers@example.com a/789 Road type/vendor c/florist`"

### Status

✅ **FIXED** - All 2 occurrences of `t/` prefix in test cases updated to `c/` to match actual implementation and User Guide.

### Rationale

The User Guide shows `c/` as the prefix for categories in commands. The actual implementation uses the `c/` prefix (PREFIX_CATEGORY = "c/") and the `t/` prefix was removed in the category refactoring. The DG test case examples must use the correct prefix to match actual command syntax.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None (implementation is correct, only DG examples needed updating)
- grep_search confirmed: No remaining `t/friends` or `t/florist` in DG examples

---

Link/Unlink Command Formatting

**Date**: 3 November 2025  
**Issue**: DG examples show `link client/1, vendor/3` with a space after the comma, but the actual implementation expects `link client/1,vendor/3` without space.  
**Reference**: GitHub Issue - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location 1 - Usage Section (Lines 312-313)**
- **Before**: 
  ```
  link client/1, vendor/3
  unlink client/1, vendor/3
  ```
- **After**: 
  ```
  link client/1,vendor/3
  unlink client/1,vendor/3
  ```

**Location 2 - Link Test Cases (Lines 840, 843, 846)**
- **Before**: `link client/1, vendor/2`, `link client/0, vendor/1`, `link client/1, vendor/999`
- **After**: `link client/1,vendor/2`, `link client/0,vendor/1`, `link client/1,vendor/999`

**Location 3 - Unlink Test Cases (Lines 858, 861, 864)**
- **Before**: `unlink client/1, vendor/2`, `unlink client/0, vendor/1`, `unlink client/1, vendor/999`
- **After**: `unlink client/1,vendor/2`, `unlink client/0,vendor/1`, `unlink client/1,vendor/999`

### Status

✅ **FIXED** - All 9 occurrences of link/unlink commands updated to remove space after comma.

### Rationale

The parser expects the link/unlink command format without spaces: `client/INDEX,vendor/INDEX`. The spaces in the DG examples were causing a mismatch between documentation and actual implementation, leading to potential confusion for users copying examples directly from the DG.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None (implementation was already correct, only DG examples needed updating)

---

JAR Filename in Launch Instructions

**Date**: 3 November 2025  
**Issue**: DG shows `java -jar tp.jar` but the actual JAR file is named `KnotBook.jar`.  
**Reference**: GitHub Issues #275, #303 - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Launch via Command Line Section (Line 788)**
- **Before**: "Open PowerShell in the folder containing the JAR and run `java -jar tp.jar`"
- **After**: "Open PowerShell in the folder containing the JAR and run `java -jar KnotBook.jar`"

### Status

✅ **FIXED** - Updated jar filename to match actual product name.

### Rationale

The application is named KnotBook, and the generated JAR file is `KnotBook.jar`. The DG should use the correct filename in all examples and instructions.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

 Acknowledgements Section Placeholder

**Date**: 3 November 2025  
**Issue**: Acknowledgements section contains placeholder text instead of actual acknowledgements.  
**Reference**: GitHub Issue #293 - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Acknowledgements Section (Line ~51)**
- **Before**: "{list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}"
- **After**: 
  * This project is based on the AddressBook-Level3 project created by the SE-EDU initiative.
  * Libraries used: JavaFX, Jackson, JUnit5, Apache Commons Validator

### Status

✅ **FIXED** - Replaced placeholder with actual acknowledgements.

### Rationale

The DG should properly acknowledge the SE-EDU AddressBook-Level3 base project and list the libraries used.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

Timestamp Reference in Delete Test Case

**Date**: 3 November 2025  
**Issue**: Delete test case mentions "Timestamp in the status bar is updated" but no timestamp is shown in the app.  
**Reference**: GitHub Issue #305 - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Delete Test Case (Line 804)**
- **Before**: "Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated."
- **After**: "Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message."

### Status

✅ **FIXED** - Removed timestamp reference.

### Rationale

The application does not display a timestamp in the status bar when contacts are deleted. The test case expected output should match actual application behavior.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

UC03 Extension 3b Category List

**Date**: 3 November 2025  
**Issue**: UC03 extension says app "shows a list of valid category types" but app only shows an error message.  
**Reference**: GitHub Issue #310 - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Use Case UC03 Extension 3b (Line ~567)**
- **Before**: 
  * 3b1. KnotBook shows a list of valid category types.
  * 3b2. User selects a valid category or creates a new one.
  * Use case resumes at step 4.
- **After**: 
  * 3b1. KnotBook shows an error message for invalid category format.
  * Use case resumes at step 2.

### Status

✅ **FIXED** - Updated to match actual application behavior.

### Rationale

The application only allows one category per vendor and shows an error message for invalid category formats. It does not display a list of valid categories or prompt the user to select from a list.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

Duplicate Phone Numbers User Story Contradiction

**Date**: 3 November 2025  
**Issue**: User story says app should "allow duplicate phone numbers" but DG clearly states app prevents duplicate phone numbers.  
**Reference**: GitHub Issue #315 - `type.FunctionalityBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - User Stories Table (Line 475)**
- **Before**: Row with user story "allow duplicate phone numbers and prices | accommodate cases where vendors share numbers or have similar pricing"
- **After**: (Removed entire row)

### Status

✅ **FIXED** - Removed contradictory user story.

### Rationale

The application intentionally prevents duplicate phone numbers as a core feature (duplicate detection uses phone number as unique identifier). This user story contradicts the actual implementation and design decisions documented throughout the DG.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

UC02 Unnecessary Steps

**Date**: 3 November 2025  
**Issue**: UC02 includes steps 3-8 for searching/viewing vendor and client details, but link command only requires indices.  
**Reference**: GitHub Issue (from tester) - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Use Case UC02 (Line ~503)**
- **Before**: 10-step MSS including vendor/client search and details viewing
- **After**: Simplified 4-step MSS:
  1. User requests to list persons
  2. KnotBook shows a list of persons
  3. User requests to link a vendor to a client by their indices
  4. KnotBook confirms the link and updates both records

### Status

✅ **FIXED** - Simplified MSS to match actual link command workflow.

### Rationale

The link command works with indices from the displayed list (`link client/1 vendor/2`). Users don't need to search for or view vendor/client details individually - they just need the list and the indices.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

UC04 Incorrect MSS Steps

**Date**: 3 November 2025  
**Issue**: UC04 separates "request update", "prompt for amount", and "enter amount" into steps 5-7, but edit command takes all parameters at once.  
**Reference**: GitHub Issue #323 - `type.DocumentationBug` - Opened 2 days ago

### Changes Made

**File**: `docs/DeveloperGuide.md`

**Location - Use Case UC04 (Line ~573)**
- **Before**: 
  5. User requests to update the quote with new pricing
  6. KnotBook prompts for the new quote amount
  7. User enters the new quote
  8. KnotBook validates and saves...
- **After**: 
  5. User enters edit command with new quote/price
  6. KnotBook validates and saves the updated quote
  7. KnotBook displays confirmation message

### Status

✅ **FIXED** - Updated MSS to reflect one-step edit command.

### Rationale

The edit command takes all parameters in one command (e.g., `edit 1 pr/2000`). The system doesn't prompt for each field separately - it's a single-step command execution.

### Verification

- Build status: ✅ PASSING
- Tests affected: None (documentation only)
- Code changes required: None

---

## Summary Table

| # | Issue | Status | File(s) | Lines | Description |
|---|-------|--------|---------|-------|-------------|
| 1 | Duplicate detection | ✅ FIXED | DeveloperGuide.md | 632, 694 | Changed "phone or email" to "phone number" |
| 2 | Wedding date prefix | ✅ FIXED | DeveloperGuide.md | 247, 666, 884 | Updated `date:` notation to `w/` across all examples |
| 3 | Category prefix notation | ✅ FIXED | DeveloperGuide.md | 884, 892 | Changed `t/` prefix to `c/` in test case examples |
| 4 | Link/unlink formatting | ✅ FIXED | DeveloperGuide.md | 312, 313, 840, 843, 846, 858, 861, 864 | Removed space after comma in link/unlink commands |
| 5 | JAR filename | ✅ FIXED | DeveloperGuide.md | 788 | Changed `tp.jar` to `KnotBook.jar` |
| 6 | Acknowledgements placeholder | ✅ FIXED | DeveloperGuide.md | ~51 | Replaced placeholder with actual acknowledgements |
| 7 | Timestamp reference | ✅ FIXED | DeveloperGuide.md | 804 | Removed non-existent timestamp from delete test |
| 8 | UC03 category list | ✅ FIXED | DeveloperGuide.md | ~567 | Removed mention of showing category list |
| 9 | Duplicate phone story | ✅ FIXED | DeveloperGuide.md | 475 | Removed contradictory user story |
| 10 | UC02 unnecessary steps | ✅ FIXED | DeveloperGuide.md | ~503 | Simplified MSS to match link command |
| 11 | UC04 incorrect MSS | ✅ FIXED | DeveloperGuide.md | ~573 | Updated MSS to reflect one-step edit command |

---

## How to Update This Document

When adding new DG fixes:

1. Add a new section with:
   - Date of fix
   - Issue description
   - Reference (GitHub issue, discussion, or finding)
   
2. List all changes made with:
   - File path
   - Specific lines/sections
   - Before and After text
   
3. Include:
   - Rationale for the fix
   - Verification status (build, tests)
   - Whether code changes were needed
   
4. Update the Summary Table at the end

---

## Notes for Contributors

- DG fixes are typically documentation-only changes (no code changes needed)
- Always verify that the implementation matches the DG before assuming DG is wrong
- Keep User Guide and DG aligned for consistency
- Test cases in DG examples should match actual command syntax
